### PR TITLE
Use a plugin to maintain the license automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,18 @@
 language: java
+jdk: oraclejdk8
+
+sudo: required
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/2.10
+    - $HOME/.gradle/caches/jars-1
+    - $HOME/.gradle/daemon
+    - $HOME/.gradle/wrapper
+
+script:
+  - ./gradlew license check --continue --stacktrace

--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,10 @@
-
-Copyright (C) 2013-2016 Pile Project <dev@pileproject.com>
+Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ uploadArchives {
             pom.artifactId = 'drivecommand'
 
             pom.project {
-                inceptionYear '2013'
+                inceptionYear '2011'
                 packaging 'jar'
                 licenses {
                     license {

--- a/build.gradle
+++ b/build.gradle
@@ -7,14 +7,12 @@
  * user guide available at http://gradle.org/docs/2.5/userguide/tutorial_java_projects.html
  */
 
-// Apply the java plugin to add support for Java
-apply plugin: 'java'
-
-// Apply the eclipse plugin to generate eclipse project files
-apply plugin: 'eclipse'
-
-// Apply the maven plugin to deploy this project to a maven repository
-apply plugin: 'maven'
+plugins {
+    id 'java'
+    id 'eclipse'
+    id 'maven'
+    id "com.github.hierynomus.license" version "0.13.1"
+}
 
 // In this section you declare where to find the dependencies of your project
 repositories {
@@ -50,6 +48,11 @@ task wraper(type: Wrapper) {
     gradleVersion = '2.5'
 }
 
+// for our license
+license {
+    header rootProject.file('LICENSE')
+    includes(["**/*.java", "**/*.xml"])
+}
 
 // Maven repository identity setting
 uploadArchives {
@@ -75,4 +78,3 @@ uploadArchives {
         }
     }
 }
-

--- a/src/main/java/com/pileproject/drivecommand/command/Command.java
+++ b/src/main/java/com/pileproject/drivecommand/command/Command.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.command;
 
 import com.pileproject.drivecommand.model.CommandType;

--- a/src/main/java/com/pileproject/drivecommand/command/CommandBase.java
+++ b/src/main/java/com/pileproject/drivecommand/command/CommandBase.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.command;
 
 import com.pileproject.drivecommand.machine.device.DeviceType;

--- a/src/main/java/com/pileproject/drivecommand/command/CommandFactory.java
+++ b/src/main/java/com/pileproject/drivecommand/command/CommandFactory.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.command;
 
 import com.pileproject.drivecommand.model.CommandType;

--- a/src/main/java/com/pileproject/drivecommand/machine/MachineBase.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/MachineBase.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine;
 
 import com.pileproject.drivecommand.machine.device.input.ColorSensor;

--- a/src/main/java/com/pileproject/drivecommand/machine/MachineStatus.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/MachineStatus.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine;
 
 import com.pileproject.drivecommand.machine.device.DeviceType;

--- a/src/main/java/com/pileproject/drivecommand/machine/device/DeviceBase.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/DeviceBase.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/main/java/com/pileproject/drivecommand/machine/device/DeviceType.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/DeviceType.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device;
 
 /**

--- a/src/main/java/com/pileproject/drivecommand/machine/device/input/ColorSensor.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/input/ColorSensor.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device.input;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/main/java/com/pileproject/drivecommand/machine/device/input/GyroSensor.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/input/GyroSensor.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device.input;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/main/java/com/pileproject/drivecommand/machine/device/input/LineSensor.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/input/LineSensor.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device.input;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/main/java/com/pileproject/drivecommand/machine/device/input/Rangefinder.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/input/Rangefinder.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device.input;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/main/java/com/pileproject/drivecommand/machine/device/input/RemoteControlReceiver.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/input/RemoteControlReceiver.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device.input;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/main/java/com/pileproject/drivecommand/machine/device/input/SoundSensor.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/input/SoundSensor.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device.input;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/main/java/com/pileproject/drivecommand/machine/device/input/TouchSensor.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/input/TouchSensor.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device.input;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/main/java/com/pileproject/drivecommand/machine/device/output/Buzzer.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/output/Buzzer.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device.output;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/main/java/com/pileproject/drivecommand/machine/device/output/Led.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/output/Led.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device.output;
 
 

--- a/src/main/java/com/pileproject/drivecommand/machine/device/output/Motor.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/output/Motor.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device.output;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/main/java/com/pileproject/drivecommand/machine/device/output/Servomotor.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/output/Servomotor.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device.output;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/main/java/com/pileproject/drivecommand/machine/device/port/DevicePort.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/port/DevicePort.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device.port;
 
 /**

--- a/src/main/java/com/pileproject/drivecommand/machine/device/port/DevicePortTypeMismatchException.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/port/DevicePortTypeMismatchException.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device.port;
 
 /***

--- a/src/main/java/com/pileproject/drivecommand/machine/device/port/InputPort.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/port/InputPort.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device.port;
 
 /**

--- a/src/main/java/com/pileproject/drivecommand/machine/device/port/OutputPort.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/port/OutputPort.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.machine.device.port;
 
 /**

--- a/src/main/java/com/pileproject/drivecommand/model/CommandType.java
+++ b/src/main/java/com/pileproject/drivecommand/model/CommandType.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model;
 
 import com.pileproject.drivecommand.machine.device.DeviceType;

--- a/src/main/java/com/pileproject/drivecommand/model/ProtocolBase.java
+++ b/src/main/java/com/pileproject/drivecommand/model/ProtocolBase.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/main/java/com/pileproject/drivecommand/model/com/ICommunicator.java
+++ b/src/main/java/com/pileproject/drivecommand/model/com/ICommunicator.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.com;
 
 import java.io.IOException;

--- a/src/main/java/com/pileproject/drivecommand/model/ev3/ByteCodeFormatter.java
+++ b/src/main/java/com/pileproject/drivecommand/model/ev3/ByteCodeFormatter.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.ev3;
 
 import com.pileproject.drivecommand.util.Log;

--- a/src/main/java/com/pileproject/drivecommand/model/ev3/Ev3Constants.java
+++ b/src/main/java/com/pileproject/drivecommand/model/ev3/Ev3Constants.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.ev3;
 
 /**

--- a/src/main/java/com/pileproject/drivecommand/model/ev3/Ev3Machine.java
+++ b/src/main/java/com/pileproject/drivecommand/model/ev3/Ev3Machine.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.ev3;
 
 import com.pileproject.drivecommand.machine.MachineBase;

--- a/src/main/java/com/pileproject/drivecommand/model/ev3/Ev3Protocol.java
+++ b/src/main/java/com/pileproject/drivecommand/model/ev3/Ev3Protocol.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.ev3;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/main/java/com/pileproject/drivecommand/model/ev3/port/Ev3InputPort.java
+++ b/src/main/java/com/pileproject/drivecommand/model/ev3/port/Ev3InputPort.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.ev3.port;
 
 import com.pileproject.drivecommand.machine.device.port.InputPort;

--- a/src/main/java/com/pileproject/drivecommand/model/ev3/port/Ev3OutputPort.java
+++ b/src/main/java/com/pileproject/drivecommand/model/ev3/port/Ev3OutputPort.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.ev3.port;
 
 import com.pileproject.drivecommand.machine.device.port.OutputPort;

--- a/src/main/java/com/pileproject/drivecommand/model/nxt/InputValues.java
+++ b/src/main/java/com/pileproject/drivecommand/model/nxt/InputValues.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.nxt;
 
 /**

--- a/src/main/java/com/pileproject/drivecommand/model/nxt/NxtConstants.java
+++ b/src/main/java/com/pileproject/drivecommand/model/nxt/NxtConstants.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.nxt;
 
 /**

--- a/src/main/java/com/pileproject/drivecommand/model/nxt/NxtMachine.java
+++ b/src/main/java/com/pileproject/drivecommand/model/nxt/NxtMachine.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.nxt;
 
 import com.pileproject.drivecommand.machine.MachineBase;

--- a/src/main/java/com/pileproject/drivecommand/model/nxt/NxtProtocol.java
+++ b/src/main/java/com/pileproject/drivecommand/model/nxt/NxtProtocol.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.nxt;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/main/java/com/pileproject/drivecommand/model/nxt/port/NxtInputPort.java
+++ b/src/main/java/com/pileproject/drivecommand/model/nxt/port/NxtInputPort.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.nxt.port;
 
 import com.pileproject.drivecommand.machine.device.port.InputPort;

--- a/src/main/java/com/pileproject/drivecommand/model/nxt/port/NxtOutputPort.java
+++ b/src/main/java/com/pileproject/drivecommand/model/nxt/port/NxtOutputPort.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.nxt.port;
 
 import com.pileproject.drivecommand.machine.device.port.OutputPort;

--- a/src/main/java/com/pileproject/drivecommand/model/pile/PileConstants.java
+++ b/src/main/java/com/pileproject/drivecommand/model/pile/PileConstants.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.pile;
 
 /**

--- a/src/main/java/com/pileproject/drivecommand/model/pile/PileMachine.java
+++ b/src/main/java/com/pileproject/drivecommand/model/pile/PileMachine.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.pile;
 
 import com.pileproject.drivecommand.machine.MachineBase;

--- a/src/main/java/com/pileproject/drivecommand/model/pile/PilePacketFormatter.java
+++ b/src/main/java/com/pileproject/drivecommand/model/pile/PilePacketFormatter.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.pile;
 
 import java.io.ByteArrayOutputStream;

--- a/src/main/java/com/pileproject/drivecommand/model/pile/PileProtocol.java
+++ b/src/main/java/com/pileproject/drivecommand/model/pile/PileProtocol.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.pile;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/main/java/com/pileproject/drivecommand/model/pile/port/PileInputPort.java
+++ b/src/main/java/com/pileproject/drivecommand/model/pile/port/PileInputPort.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.pile.port;
 
 import com.pileproject.drivecommand.machine.device.port.InputPort;

--- a/src/main/java/com/pileproject/drivecommand/model/pile/port/PileOutputPort.java
+++ b/src/main/java/com/pileproject/drivecommand/model/pile/port/PileOutputPort.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.model.pile.port;
 
 import com.pileproject.drivecommand.machine.device.port.OutputPort;

--- a/src/main/java/com/pileproject/drivecommand/util/Log.java
+++ b/src/main/java/com/pileproject/drivecommand/util/Log.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package com.pileproject.drivecommand.util;
 
 /**

--- a/src/test/java/unit/drivecommand/command/CommandFactoryTest.java
+++ b/src/test/java/unit/drivecommand/command/CommandFactoryTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.command;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/test/java/unit/drivecommand/machine/MachineBaseTest.java
+++ b/src/test/java/unit/drivecommand/machine/MachineBaseTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.machine;
 
 import com.pileproject.drivecommand.machine.MachineBase;

--- a/src/test/java/unit/drivecommand/machine/device/input/ColorSensorTest.java
+++ b/src/test/java/unit/drivecommand/machine/device/input/ColorSensorTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.machine.device.input;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/test/java/unit/drivecommand/machine/device/input/GyroSensorTest.java
+++ b/src/test/java/unit/drivecommand/machine/device/input/GyroSensorTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.machine.device.input;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/test/java/unit/drivecommand/machine/device/input/LineSensorTest.java
+++ b/src/test/java/unit/drivecommand/machine/device/input/LineSensorTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.machine.device.input;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/test/java/unit/drivecommand/machine/device/input/RangefinderTest.java
+++ b/src/test/java/unit/drivecommand/machine/device/input/RangefinderTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.machine.device.input;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/test/java/unit/drivecommand/machine/device/input/RemoteControlReceiverTest.java
+++ b/src/test/java/unit/drivecommand/machine/device/input/RemoteControlReceiverTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.machine.device.input;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/test/java/unit/drivecommand/machine/device/input/SoundSensorTest.java
+++ b/src/test/java/unit/drivecommand/machine/device/input/SoundSensorTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.machine.device.input;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/test/java/unit/drivecommand/machine/device/input/TouchSensorTest.java
+++ b/src/test/java/unit/drivecommand/machine/device/input/TouchSensorTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.machine.device.input;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/test/java/unit/drivecommand/machine/device/output/BuzzerTest.java
+++ b/src/test/java/unit/drivecommand/machine/device/output/BuzzerTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.machine.device.output;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/test/java/unit/drivecommand/machine/device/output/LedTest.java
+++ b/src/test/java/unit/drivecommand/machine/device/output/LedTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.machine.device.output;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/test/java/unit/drivecommand/machine/device/output/MotorTest.java
+++ b/src/test/java/unit/drivecommand/machine/device/output/MotorTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.machine.device.output;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/test/java/unit/drivecommand/machine/device/output/ServoMotorTest.java
+++ b/src/test/java/unit/drivecommand/machine/device/output/ServoMotorTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.machine.device.output;
 
 import com.pileproject.drivecommand.command.CommandBase;

--- a/src/test/java/unit/drivecommand/model/ev3/Ev3MachineTest.java
+++ b/src/test/java/unit/drivecommand/model/ev3/Ev3MachineTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.model.ev3;
 
 import com.pileproject.drivecommand.machine.MachineBase;

--- a/src/test/java/unit/drivecommand/model/ev3/Ev3ProtocolTest.java
+++ b/src/test/java/unit/drivecommand/model/ev3/Ev3ProtocolTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.model.ev3;
 
 import com.pileproject.drivecommand.model.ProtocolBase;

--- a/src/test/java/unit/drivecommand/model/ev3/port/Ev3InputPortTest.java
+++ b/src/test/java/unit/drivecommand/model/ev3/port/Ev3InputPortTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.model.ev3.port;
 
 import com.pileproject.drivecommand.model.ev3.port.Ev3InputPort;

--- a/src/test/java/unit/drivecommand/model/ev3/port/Ev3OutputPortTest.java
+++ b/src/test/java/unit/drivecommand/model/ev3/port/Ev3OutputPortTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.model.ev3.port;
 
 import com.pileproject.drivecommand.model.ev3.port.Ev3OutputPort;

--- a/src/test/java/unit/drivecommand/model/nxt/NxtMachineTest.java
+++ b/src/test/java/unit/drivecommand/model/nxt/NxtMachineTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.model.nxt;
 
 import com.pileproject.drivecommand.machine.MachineBase;

--- a/src/test/java/unit/drivecommand/model/nxt/NxtProtocolTest.java
+++ b/src/test/java/unit/drivecommand/model/nxt/NxtProtocolTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.model.nxt;
 
 import com.pileproject.drivecommand.model.ProtocolBase;

--- a/src/test/java/unit/drivecommand/model/nxt/port/NxtInputPortTest.java
+++ b/src/test/java/unit/drivecommand/model/nxt/port/NxtInputPortTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.model.nxt.port;
 
 import com.pileproject.drivecommand.model.nxt.port.NxtInputPort;

--- a/src/test/java/unit/drivecommand/model/nxt/port/NxtOutputPortTest.java
+++ b/src/test/java/unit/drivecommand/model/nxt/port/NxtOutputPortTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.model.nxt.port;
 
 import com.pileproject.drivecommand.model.nxt.port.NxtOutputPort;

--- a/src/test/java/unit/drivecommand/model/pile/PileMachineTest.java
+++ b/src/test/java/unit/drivecommand/model/pile/PileMachineTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.model.pile;
 
 import com.pileproject.drivecommand.machine.MachineBase;

--- a/src/test/java/unit/drivecommand/model/pile/PilePacketFormatterTest.java
+++ b/src/test/java/unit/drivecommand/model/pile/PilePacketFormatterTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.model.pile;
 
 import com.pileproject.drivecommand.model.pile.PileConstants;

--- a/src/test/java/unit/drivecommand/model/pile/PileProtocolTest.java
+++ b/src/test/java/unit/drivecommand/model/pile/PileProtocolTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.model.pile;
 
 import com.pileproject.drivecommand.model.ProtocolBase;

--- a/src/test/java/unit/drivecommand/model/pile/port/PileInputPortTest.java
+++ b/src/test/java/unit/drivecommand/model/pile/port/PileInputPortTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.model.pile.port;
 
 import com.pileproject.drivecommand.model.pile.port.PileInputPort;

--- a/src/test/java/unit/drivecommand/model/pile/port/PileOutputPortTest.java
+++ b/src/test/java/unit/drivecommand/model/pile/port/PileOutputPortTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 The DriveCommand Authors <pile-dev@googlegroups.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package unit.drivecommand.model.pile.port;
 
 import com.pileproject.drivecommand.model.pile.port.PileOutputPort;


### PR DESCRIPTION
I made a change to use [the same plugin](https://github.com/hierynomus/license-gradle-plugin) that is used in [drive](https://github.com/PileProject/drive) to maintain LICENSE automatically. 

For the purpose, I also changed the `.travis.yml` to run a test and license check (it did nothing).

### NOTE
I changed the name of LICENSE author and the e-mail.