### PR TITLE
Introduce an auto deploy feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ deploy:
   on:
     branch: master
     tags: true
+    condition: "$TRAVIS_TAG =~ ^v[0-9].*$"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,24 @@
 language: java
 jdk: oraclejdk8
-
 sudo: required
-
+env:
+  global:
+  - secure: hR4oxYjZ1wkDcd1O+z8wXCyrNw2BXCtwxd41BfBC6O1IcQzE4csFjJBVJxSHmpII+8v3eJ7sEelLiCubEWUB+o1p1vkBjf48OOE2btnQdr1wY7x8LxTpQEl9Jgi2te22lFIBiREdQuTCu1xhFsOcnW7EHtvnAHrEBbhQQy6p3R/Uq629kyfjgpOQi4DBmRwd4Q+YNhN7N1T4e58RC8ppoY2fP2+PR3NEVjZgMwoGpst1PNcO39nQczE8GXDW+puAozkcnA0SuDnuEOtvHb5YJLt635/z/obHXFt0vcZannxSQdMynQMM2eeWQp/yZXAdTM4SOX2qjj+oOxOErm9FRCT2adnvDLYgYCt61B8g7nvJ8TgD09HAnhvRgltbqlpjtp+tLvR2nM2nEFuR1onuPLKgH2cQwJHWbC99Oug74Y/OwxN6Y7uWjOFvm1nYY66EOHa/EhtuCxWejGWVj2M396t7U6TnbvOep8Jw0ANYCY3NwIEbtI8o/ePydUTllQVjvO2xmEMH87X1WJnUjVZkr/98OwcZj6ZrIbr0jy/YE4vxbTXOT3sxrRvwi2XdClSeRnc6rYoTE2I8zohnt5YZMC7qB2idQ8sJSoHnwUYk60aGzYs57D9mCeNvBcUCmkzDk856US2PZFY2EPNbd5gLJ8T2S3Tx5iCDBTBu0LuOOBY=
 before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-
+- rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+- rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
-    - $HOME/.gradle/caches/2.10
-    - $HOME/.gradle/caches/jars-1
-    - $HOME/.gradle/daemon
-    - $HOME/.gradle/wrapper
-
+  - "$HOME/.gradle/caches/2.10"
+  - "$HOME/.gradle/caches/jars-1"
+  - "$HOME/.gradle/daemon"
+  - "$HOME/.gradle/wrapper"
 script:
-  - ./gradlew license check --continue --stacktrace
+- "./gradlew license check --continue --stacktrace"
+deploy:
+  provider: script
+  script: scripts/deploy-gh-pages.sh
+  skip_cleanup: true
+  on:
+    branch: master
+    tags: true

--- a/build.gradle
+++ b/build.gradle
@@ -44,10 +44,6 @@ dependencies {
 
 }
 
-task wraper(type: Wrapper) {
-    gradleVersion = '2.5'
-}
-
 // for our license
 license {
     header rootProject.file('LICENSE')
@@ -55,26 +51,42 @@ license {
 }
 
 // Maven repository identity setting
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            repository url: "file:${projectDir}"
+uploadArchives.repositories.mavenDeployer {
+    repository url: "file:${projectDir}/docs"
+    pom {
+        version = 'unspecified'
+        groupId = 'com.pileproject'
+        artifactId = 'drivecommand'
 
-            pom.version = '2.1.0'
-            pom.groupId = 'com.pileproject'
-            pom.artifactId = 'drivecommand'
-
-            pom.project {
-                inceptionYear '2011'
-                packaging 'jar'
-                licenses {
-                    license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        distribution 'repo'
-                    }
+        project {
+            inceptionYear '2011'
+            packaging 'jar'
+            licenses {
+                license {
+                    name 'The Apache Software License, Version 2.0'
+                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    distribution 'repo'
                 }
             }
         }
+    }
+}
+
+task deploy {
+    description = "Deploys current sourceset into .jar file via 'uploadArchives' task."
+
+    doLast {
+        if (!project.hasProperty('tag')) {
+            throw new GradleException('Tag not specified. Run with -Ptag=$TAG')
+        }
+
+        if (!(project.tag =~ /^v\d.*$/)) {
+            throw new GradleException('Wrong format tag. A tag for deploy should be /^v[0-9].*$/')
+        }
+
+        // remove the prefix 'v'
+        uploadArchives.repositories.mavenDeployer.pom.version = project.tag.substring(1)
+
+        uploadArchives.execute()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -90,3 +90,5 @@ task deploy {
         uploadArchives.execute()
     }
 }
+
+deploy.dependsOn build

--- a/scripts/deploy-gh-pages.sh
+++ b/scripts/deploy-gh-pages.sh
@@ -1,53 +1,25 @@
 #!/bin/bash
-set -e # Exit with nonzero exit code if anything fails
+set -eu
 
-mkdir tmp
-cd tmp
-
-SOURCE_BRANCH="master"
-TARGET_BRANCH="gh-pages"
-
-# Pull requests and commits to other branches shouldn't try to deploy, just build to verify
-if [ "$TRAVIS_PULL_REQUEST" != "false" -o -z "$TRAVIS_TAG" ]; then
-    echo "Skipping deploy"
-    exit 0
-fi
-
-# Save some useful information
+# get the remote URL
 REPO=`git config remote.origin.url`
 REPO_WITH_TOKEN=${REPO/https:\/\/github.com\//https://${GH_TOKEN}@github.com/}
 
-# Clone the existing gh-pages for this repo into out/
-# Create a new empty branch if gh-pages doesn't exist yet (should only happen on first deply)
-git clone $REPO src
-cd src; git checkout $SOURCE_BRANCH
+rootdir=`pwd`
+tmpdir="${rootdir}/`mktemp -d`"
 
-# Build
-./gradlew uploadArchives
+git clone $REPO $tmpdir
+cd $tmpdir
 
-cd ..
+# build a release
+./gradlew deploy -Ptag=$TRAVIS_TAG
 
-git clone $REPO tgt
-cd tgt; git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
-
-cd ..
-
-# Copy output files
-cp -r src/com/pileproject/drivecommand/* tgt/com/pileproject/drivecommand
-
-# Now let's go have some fun with the cloned repo
-cd tgt
+# commit the changes
 git config --global user.email "travis@travis-ci.org"
 git config --global user.name "Travis"
 
-# If there are no changes (e.g. this is a README update) then just bail.
-if [ -z `git diff --exit-code` ]; then
-    echo "No changes to the spec on this push; exiting."
-    exit 0
-fi
-
-# Commit the "changes", i.e. the new version.
-# The delta will show diffs between new and old versions.
 git add .
 git commit -m "Release ${TRAVIS_TAG}"
-git push --quiet $REPO_WITH_TOKEN $TARGET_BRANCH
+git push --quiet $REPO_WITH_TOKEN master
+
+echo "Released ${TRAVIS_TAG}"

--- a/scripts/deploy-gh-pages.sh
+++ b/scripts/deploy-gh-pages.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e # Exit with nonzero exit code if anything fails
+
+mkdir tmp
+cd tmp
+
+SOURCE_BRANCH="master"
+TARGET_BRANCH="gh-pages"
+
+# Pull requests and commits to other branches shouldn't try to deploy, just build to verify
+if [ "$TRAVIS_PULL_REQUEST" != "false" -o -z "$TRAVIS_TAG" ]; then
+    echo "Skipping deploy"
+    exit 0
+fi
+
+# Save some useful information
+REPO=`git config remote.origin.url`
+REPO_WITH_TOKEN=${REPO/https:\/\/github.com\//https://${GH_TOKEN}@github.com/}
+
+# Clone the existing gh-pages for this repo into out/
+# Create a new empty branch if gh-pages doesn't exist yet (should only happen on first deply)
+git clone $REPO src
+cd src; git checkout $SOURCE_BRANCH
+
+# Build
+./gradlew uploadArchives
+
+cd ..
+
+git clone $REPO tgt
+cd tgt; git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
+
+cd ..
+
+# Copy output files
+cp -r src/com/pileproject/drivecommand/* tgt/com/pileproject/drivecommand
+
+# Now let's go have some fun with the cloned repo
+cd tgt
+git config --global user.email "travis@travis-ci.org"
+git config --global user.name "Travis"
+
+# If there are no changes (e.g. this is a README update) then just bail.
+if [ -z `git diff --exit-code` ]; then
+    echo "No changes to the spec on this push; exiting."
+    exit 0
+fi
+
+# Commit the "changes", i.e. the new version.
+# The delta will show diffs between new and old versions.
+git add .
+git commit -m "Release ${TRAVIS_TAG}"
+git push --quiet $REPO_WITH_TOKEN $TARGET_BRANCH

--- a/scripts/deploy-gh-pages.sh
+++ b/scripts/deploy-gh-pages.sh
@@ -11,7 +11,6 @@ git clone -b master $REPO $tmpdir
 cd $tmpdir
 
 # build a release
-./gradlew build
 ./gradlew deploy -Ptag=$TRAVIS_TAG
 
 # commit the changes

--- a/scripts/deploy-gh-pages.sh
+++ b/scripts/deploy-gh-pages.sh
@@ -5,13 +5,13 @@ set -eu
 REPO=`git config remote.origin.url`
 REPO_WITH_TOKEN=${REPO/https:\/\/github.com\//https://${GH_TOKEN}@github.com/}
 
-rootdir=`pwd`
-tmpdir="${rootdir}/`mktemp -d`"
+tmpdir=`mktemp -d`
 
-git clone $REPO $tmpdir
+git clone -b master $REPO $tmpdir
 cd $tmpdir
 
 # build a release
+./gradlew build
 ./gradlew deploy -Ptag=$TRAVIS_TAG
 
 # commit the changes


### PR DESCRIPTION
resolves #20.

This PR introduces a feature of auto deploy.

### Procedure
1. Merge changes into `master` (e.g., `git checkout master; git merge develop`)
1. Edit the version of the project in `build.gradle` ([this line](https://github.com/PileProject/drivecommand/blob/37a4b6f7f83d76a6de077aedb7052be701df719f/build.gradle#L63))
1. Run a task (`./gradlew uploadArchives`)
1. Make a commit (e.g., `git add .; git commit -m "Release v2.2.0"`)
1. Make a tag (e.g., `git tag v2.2.0`)
1. Push changes (`git push --follow-tags`)

Then, `gh-pages` branch will be updated automatically :tada:

### References
- [promises-guide/deploy-gh-pages.sh at master · w3ctag/promises-guide]( https://goo.gl/6816am )
- (Japanese) [Travis CI経由でgh-pagesにmiddlemanで構築した静的サイトをデプロイ。 - Qiita]( https://goo.gl/GxNSIq )