### PR TITLE
Rename LineSensor to LightSensor

### DIFF
--- a/src/main/java/com/pileproject/drivecommand/machine/MachineBase.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/MachineBase.java
@@ -17,7 +17,7 @@ package com.pileproject.drivecommand.machine;
 
 import com.pileproject.drivecommand.machine.device.input.ColorSensor;
 import com.pileproject.drivecommand.machine.device.input.GyroSensor;
-import com.pileproject.drivecommand.machine.device.input.LineSensor;
+import com.pileproject.drivecommand.machine.device.input.LightSensor;
 import com.pileproject.drivecommand.machine.device.input.Rangefinder;
 import com.pileproject.drivecommand.machine.device.input.RemoteControlReceiver;
 import com.pileproject.drivecommand.machine.device.input.SoundSensor;
@@ -138,13 +138,13 @@ public abstract class MachineBase {
     }
 
     /**
-     * Creates a {@link LineSensor}.
+     * Creates a {@link LightSensor}.
      *
      * @param port an {@link InputPort} which is supposed to be bounded
-     * @return a {@link LineSensor} which is connected to the specified port
+     * @return a {@link LightSensor} which is connected to the specified port
      */
-    public LineSensor createLineSensor(InputPort port) {
-        throw new UnsupportedOperationException("This machine does not support LineSensor");
+    public LightSensor createLightSensor(InputPort port) {
+        throw new UnsupportedOperationException("This machine does not support LightSensor");
     }
 
     /**

--- a/src/main/java/com/pileproject/drivecommand/machine/device/DeviceType.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/DeviceType.java
@@ -34,7 +34,7 @@ public enum DeviceType {
     /**
      * e.g., LightSensor for EV3
      */
-    LINE_SENSOR,
+    LIGHT_SENSOR,
     GYRO_SENSOR,
     TOUCH_SENSOR,
     COLOR_SENSOR,

--- a/src/main/java/com/pileproject/drivecommand/machine/device/input/LightSensor.java
+++ b/src/main/java/com/pileproject/drivecommand/machine/device/input/LightSensor.java
@@ -26,12 +26,11 @@ import com.pileproject.drivecommand.model.ProtocolBase;
 import java.util.Map;
 
 /**
- * A line sensor class.
- * This is also known as 'light' sensor for EV3.
+ * A light sensor class.
  */
-public class LineSensor extends DeviceBase {
+public class LightSensor extends DeviceBase {
 
-    public LineSensor(InputPort port, ProtocolBase protocol) {
+    public LightSensor(InputPort port, ProtocolBase protocol) {
         super(port, protocol);
     }
 
@@ -41,13 +40,13 @@ public class LineSensor extends DeviceBase {
      * @return sensor value (0 - 100%)
      */
     public int getSensorValue() {
-        CommandBase cmd = CommandFactory.createCommand(CommandType.GET_LINE_VALUE, null);
+        CommandBase cmd = CommandFactory.createCommand(CommandType.GET_LIGHT_VALUE, null);
         Map<String, Object> value = exec(cmd);
         return (Integer) value.get("value");
     }
 
     @Override
     public DeviceType getDeviceType() {
-        return DeviceType.LINE_SENSOR;
+        return DeviceType.LIGHT_SENSOR;
     }
 }

--- a/src/main/java/com/pileproject/drivecommand/model/CommandType.java
+++ b/src/main/java/com/pileproject/drivecommand/model/CommandType.java
@@ -70,10 +70,10 @@ public enum CommandType {
             return DeviceType.BUZZER;
         }
     },
-    GET_LINE_VALUE {
+    GET_LIGHT_VALUE {
         @Override
         public DeviceType getDeviceType() {
-            return DeviceType.LINE_SENSOR;
+            return DeviceType.LIGHT_SENSOR;
         }
     },
     GET_GYRO_ANGLE {

--- a/src/main/java/com/pileproject/drivecommand/model/ev3/Ev3Machine.java
+++ b/src/main/java/com/pileproject/drivecommand/model/ev3/Ev3Machine.java
@@ -20,7 +20,7 @@ import com.pileproject.drivecommand.machine.MachineStatus;
 import com.pileproject.drivecommand.machine.device.DeviceType;
 import com.pileproject.drivecommand.machine.device.input.ColorSensor;
 import com.pileproject.drivecommand.machine.device.input.GyroSensor;
-import com.pileproject.drivecommand.machine.device.input.LineSensor;
+import com.pileproject.drivecommand.machine.device.input.LightSensor;
 import com.pileproject.drivecommand.machine.device.input.Rangefinder;
 import com.pileproject.drivecommand.machine.device.input.RemoteControlReceiver;
 import com.pileproject.drivecommand.machine.device.input.SoundSensor;
@@ -88,11 +88,11 @@ public class Ev3Machine extends MachineBase {
     }
 
     @Override
-    public LineSensor createLineSensor(InputPort port) {
+    public LightSensor createLightSensor(InputPort port) {
         checkInputPortCompatibility(port);
 
-        mStatus.bind(port, DeviceType.LINE_SENSOR);
-        return new LineSensor(port, mProtocol);
+        mStatus.bind(port, DeviceType.LIGHT_SENSOR);
+        return new LightSensor(port, mProtocol);
     }
 
     @Override

--- a/src/main/java/com/pileproject/drivecommand/model/ev3/Ev3Protocol.java
+++ b/src/main/java/com/pileproject/drivecommand/model/ev3/Ev3Protocol.java
@@ -113,7 +113,7 @@ public class Ev3Protocol extends ProtocolBase {
                 res.put(KEY_VALUE, (int) value[0]);
                 break;
             }
-            case GET_LINE_VALUE: {
+            case GET_LIGHT_VALUE: {
                 // TODO: NOT TESTED
                 short[] values = getPercentValue(port, NXT_LIGHT, LIGHT_REFLECT, 1);
                 res.put(KEY_VALUE, (int) values[0]);

--- a/src/main/java/com/pileproject/drivecommand/model/nxt/NxtMachine.java
+++ b/src/main/java/com/pileproject/drivecommand/model/nxt/NxtMachine.java
@@ -18,7 +18,7 @@ package com.pileproject.drivecommand.model.nxt;
 import com.pileproject.drivecommand.machine.MachineBase;
 import com.pileproject.drivecommand.machine.MachineStatus;
 import com.pileproject.drivecommand.machine.device.DeviceType;
-import com.pileproject.drivecommand.machine.device.input.LineSensor;
+import com.pileproject.drivecommand.machine.device.input.LightSensor;
 import com.pileproject.drivecommand.machine.device.input.SoundSensor;
 import com.pileproject.drivecommand.machine.device.input.TouchSensor;
 import com.pileproject.drivecommand.machine.device.output.Motor;
@@ -57,11 +57,11 @@ public class NxtMachine extends MachineBase {
     }
 
     @Override
-    public LineSensor createLineSensor(InputPort port) {
+    public LightSensor createLightSensor(InputPort port) {
         checkInputPortCompatibility(port);
 
-        mStatus.bind(port, DeviceType.LINE_SENSOR);
-        return new LineSensor(port, mProtocol);
+        mStatus.bind(port, DeviceType.LIGHT_SENSOR);
+        return new LightSensor(port, mProtocol);
     }
 
     @Override

--- a/src/main/java/com/pileproject/drivecommand/model/nxt/NxtProtocol.java
+++ b/src/main/java/com/pileproject/drivecommand/model/nxt/NxtProtocol.java
@@ -70,7 +70,7 @@ public class NxtProtocol extends ProtocolBase {
         Map<String, Object> res = new HashMap<>();
         CommandType type = cmd.getCommandType();
         switch (type) {
-            case GET_LINE_VALUE: {
+            case GET_LIGHT_VALUE: {
                 setInputMode(port, LIGHT_ACTIVE, PCTFULLSCALEMODE);
                 InputValues values = getInputValues(port);
                 res.put(KEY_VALUE, values.scaledValue / 10);

--- a/src/main/java/com/pileproject/drivecommand/model/pile/PileConstants.java
+++ b/src/main/java/com/pileproject/drivecommand/model/pile/PileConstants.java
@@ -135,7 +135,7 @@ public class PileConstants {
          */
         DISTANCE(0x11),
         /**
-         * Returns the brightness from a line sensor.
+         * Returns the brightness from a light sensor.
          *
          * <pre><code>
          *  INPUT:  |PORT[1 byte]|
@@ -158,7 +158,7 @@ public class PileConstants {
          * </ul>
          * If <code>PORT</code> is out of range, <code>BRIGHTNESS</code> will be zero.
          */
-        LINESENSOR(0x12),
+        LIGHTSENSOR(0x12),
         /**
          * Changes the status of a LED.
          * <p><b>NOTE: It is necessary to call {@link #APPLY} command after this command.</b></p>

--- a/src/main/java/com/pileproject/drivecommand/model/pile/PileMachine.java
+++ b/src/main/java/com/pileproject/drivecommand/model/pile/PileMachine.java
@@ -17,7 +17,7 @@ package com.pileproject.drivecommand.model.pile;
 
 import com.pileproject.drivecommand.machine.MachineBase;
 import com.pileproject.drivecommand.machine.MachineStatus;
-import com.pileproject.drivecommand.machine.device.input.LineSensor;
+import com.pileproject.drivecommand.machine.device.input.LightSensor;
 import com.pileproject.drivecommand.machine.device.input.Rangefinder;
 import com.pileproject.drivecommand.machine.device.input.TouchSensor;
 import com.pileproject.drivecommand.machine.device.output.Motor;
@@ -61,16 +61,16 @@ public class PileMachine extends MachineBase {
     }
 
     @Override
-    public LineSensor createLineSensor(InputPort port) {
-        if (port.equals(PileInputPort.LINE_SENSOR_L)
-                || port.equals(PileInputPort.LINE_SENSOR_R)) {
-            return new LineSensor(port, mProtocol);
+    public LightSensor createLightSensor(InputPort port) {
+        if (port.equals(PileInputPort.LIGHT_SENSOR_L)
+                || port.equals(PileInputPort.LIGHT_SENSOR_R)) {
+            return new LightSensor(port, mProtocol);
         }
 
         throw new DevicePortTypeMismatchException(String.format(
                 "Expected: %s or %s, Actual %s",
-                PileInputPort.LINE_SENSOR_L,
-                PileInputPort.LINE_SENSOR_R,
+                PileInputPort.LIGHT_SENSOR_L,
+                PileInputPort.LIGHT_SENSOR_R,
                 port));
     }
 

--- a/src/main/java/com/pileproject/drivecommand/model/pile/PileProtocol.java
+++ b/src/main/java/com/pileproject/drivecommand/model/pile/PileProtocol.java
@@ -51,8 +51,8 @@ public class PileProtocol extends ProtocolBase {
         Map<String, Object> res = new HashMap<>();
         CommandType type = cmd.getCommandType();
         switch (type) {
-            case GET_LINE_VALUE: {
-                int response = requestOneByte(port, PileConstants.CommandTypes.LINESENSOR);
+            case GET_LIGHT_VALUE: {
+                int response = requestOneByte(port, PileConstants.CommandTypes.LIGHTSENSOR);
                 res.put(KEY_VALUE, response);
                 break;
             }

--- a/src/main/java/com/pileproject/drivecommand/model/pile/port/PileInputPort.java
+++ b/src/main/java/com/pileproject/drivecommand/model/pile/port/PileInputPort.java
@@ -22,17 +22,17 @@ import com.pileproject.drivecommand.machine.device.port.InputPort;
  *
  * There are static instances of this class:
  * <ul>
- *  <li>{@link PileInputPort#LINE_SENSOR_L}</li>
- *  <li>{@link PileInputPort#LINE_SENSOR_R}</li>
+ *  <li>{@link PileInputPort#LIGHT_SENSOR_L}</li>
+ *  <li>{@link PileInputPort#LIGHT_SENSOR_R}</li>
  *  <li>{@link PileInputPort#TOUCH_SENSOR}</li>
  *  <li>{@link PileInputPort#RANGEFINDER}</li>
  * </ul>
  */
 public class PileInputPort extends InputPort {
-    public static final PileInputPort LINE_SENSOR_L
-            = new PileInputPort(0, Type.LINE_SENSOR_L);
-    public static final PileInputPort LINE_SENSOR_R
-            = new PileInputPort(1, Type.LINE_SENSOR_R);
+    public static final PileInputPort LIGHT_SENSOR_L
+            = new PileInputPort(0, Type.LIGHT_SENSOR_L);
+    public static final PileInputPort LIGHT_SENSOR_R
+            = new PileInputPort(1, Type.LIGHT_SENSOR_R);
     public static final PileInputPort TOUCH_SENSOR
             = new PileInputPort(0, Type.TOUCH_SENSOR);
     public static final PileInputPort RANGEFINDER
@@ -57,6 +57,6 @@ public class PileInputPort extends InputPort {
     }
 
     private enum Type {
-        LINE_SENSOR_R, LINE_SENSOR_L, TOUCH_SENSOR, RANGEFINDER
+        LIGHT_SENSOR_R, LIGHT_SENSOR_L, TOUCH_SENSOR, RANGEFINDER
     }
 }

--- a/src/test/java/unit/drivecommand/machine/MachineBaseTest.java
+++ b/src/test/java/unit/drivecommand/machine/MachineBaseTest.java
@@ -114,9 +114,9 @@ public class MachineBaseTest {
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
-    public void getLineSensorFromAndThrowAnException() {
+    public void getLightSensorFromAndThrowAnException() {
         MachineBase machineBase = newMachineBase(protocol);
-        machineBase.createLineSensor(IN_PORT);
+        machineBase.createLightSensor(IN_PORT);
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)

--- a/src/test/java/unit/drivecommand/machine/device/input/LightSensorTest.java
+++ b/src/test/java/unit/drivecommand/machine/device/input/LightSensorTest.java
@@ -17,7 +17,7 @@ package unit.drivecommand.machine.device.input;
 
 import com.pileproject.drivecommand.command.CommandBase;
 import com.pileproject.drivecommand.machine.device.DeviceType;
-import com.pileproject.drivecommand.machine.device.input.LineSensor;
+import com.pileproject.drivecommand.machine.device.input.LightSensor;
 import com.pileproject.drivecommand.machine.device.port.InputPort;
 import com.pileproject.drivecommand.model.ProtocolBase;
 import com.pileproject.drivecommand.model.nxt.port.NxtInputPort;
@@ -31,7 +31,7 @@ import mockit.Expectations;
 import mockit.Mocked;
 
 @SuppressWarnings("serial")
-public class LineSensorTest {
+public class LightSensorTest {
     @Mocked
     private ProtocolBase protocol;
     private final InputPort PORT = new InputPort() {
@@ -52,13 +52,13 @@ public class LineSensorTest {
             }};
         }};
 
-        LineSensor ls = new LineSensor(PORT, protocol);
+        LightSensor ls = new LightSensor(PORT, protocol);
         AssertJUnit.assertEquals(ls.getSensorValue(), VALUE_SENSOR);
     }
     
     @Test
-    public void deviceTypeIsLineSensor() {
-        LineSensor ls = new LineSensor(NxtInputPort.PORT_1, protocol);
-        AssertJUnit.assertEquals(ls.getDeviceType(), DeviceType.LINE_SENSOR);
+    public void deviceTypeIsLightSensor() {
+        LightSensor ls = new LightSensor(NxtInputPort.PORT_1, protocol);
+        AssertJUnit.assertEquals(ls.getDeviceType(), DeviceType.LIGHT_SENSOR);
     }
 }

--- a/src/test/java/unit/drivecommand/model/ev3/Ev3MachineTest.java
+++ b/src/test/java/unit/drivecommand/model/ev3/Ev3MachineTest.java
@@ -18,7 +18,7 @@ package unit.drivecommand.model.ev3;
 import com.pileproject.drivecommand.machine.MachineBase;
 import com.pileproject.drivecommand.machine.device.input.ColorSensor;
 import com.pileproject.drivecommand.machine.device.input.GyroSensor;
-import com.pileproject.drivecommand.machine.device.input.LineSensor;
+import com.pileproject.drivecommand.machine.device.input.LightSensor;
 import com.pileproject.drivecommand.machine.device.input.Rangefinder;
 import com.pileproject.drivecommand.machine.device.input.RemoteControlReceiver;
 import com.pileproject.drivecommand.machine.device.input.SoundSensor;
@@ -83,9 +83,9 @@ public class Ev3MachineTest {
     }
 
     @Test
-    public void createLineSensorSuccessfully() throws Exception {
+    public void createLightSensorSuccessfully() throws Exception {
         MachineBase machine = new Ev3Machine(communicator);
-        assertTrue(machine.createLineSensor(IN_PORT) instanceof LineSensor);
+        assertTrue(machine.createLightSensor(IN_PORT) instanceof LightSensor);
     }
 
     @Test

--- a/src/test/java/unit/drivecommand/model/nxt/NxtMachineTest.java
+++ b/src/test/java/unit/drivecommand/model/nxt/NxtMachineTest.java
@@ -16,7 +16,7 @@
 package unit.drivecommand.model.nxt;
 
 import com.pileproject.drivecommand.machine.MachineBase;
-import com.pileproject.drivecommand.machine.device.input.LineSensor;
+import com.pileproject.drivecommand.machine.device.input.LightSensor;
 import com.pileproject.drivecommand.machine.device.input.SoundSensor;
 import com.pileproject.drivecommand.machine.device.input.TouchSensor;
 import com.pileproject.drivecommand.machine.device.output.Motor;
@@ -58,9 +58,9 @@ public class NxtMachineTest {
     }
 
     @Test
-    public void createLineSensorSuccessfully() throws Exception {
+    public void createLightSensorSuccessfully() throws Exception {
         MachineBase machine = new NxtMachine(communicator);
-        assertTrue(machine.createLineSensor(IN_PORT) instanceof LineSensor);
+        assertTrue(machine.createLightSensor(IN_PORT) instanceof LightSensor);
     }
 
     @Test

--- a/src/test/java/unit/drivecommand/model/pile/PileMachineTest.java
+++ b/src/test/java/unit/drivecommand/model/pile/PileMachineTest.java
@@ -16,7 +16,7 @@
 package unit.drivecommand.model.pile;
 
 import com.pileproject.drivecommand.machine.MachineBase;
-import com.pileproject.drivecommand.machine.device.input.LineSensor;
+import com.pileproject.drivecommand.machine.device.input.LightSensor;
 import com.pileproject.drivecommand.machine.device.input.Rangefinder;
 import com.pileproject.drivecommand.machine.device.input.TouchSensor;
 import com.pileproject.drivecommand.machine.device.output.Motor;
@@ -68,10 +68,10 @@ public class PileMachineTest {
     }
 
     @Test
-    public void createLineSensorSuccessfully() throws Exception {
+    public void createLightSensorSuccessfully() throws Exception {
         MachineBase machine = new PileMachine(communicator);
-        assertTrue(machine.createLineSensor(PileInputPort.LINE_SENSOR_L)
-                           instanceof LineSensor);
+        assertTrue(machine.createLightSensor(PileInputPort.LIGHT_SENSOR_L)
+                           instanceof LightSensor);
     }
 
     @Test

--- a/src/test/java/unit/drivecommand/model/pile/port/PileInputPortTest.java
+++ b/src/test/java/unit/drivecommand/model/pile/port/PileInputPortTest.java
@@ -31,15 +31,15 @@ public class PileInputPortTest {
     @DataProvider(name = "ports")
     public static Object[][] ports() {
         return new Object[][] {
-                { PileInputPort.LINE_SENSOR_L },
-                { PileInputPort.LINE_SENSOR_R },
+                { PileInputPort.LIGHT_SENSOR_L},
+                { PileInputPort.LIGHT_SENSOR_R},
                 { PileInputPort.TOUCH_SENSOR },
                 { PileInputPort.RANGEFINDER },
         };
     }
 
     public static Pattern pattern = Pattern.compile(
-            "^\\[PILE\\] INPUT-PORT-(LINE_SENSOR_*|TOUCH_SENSOR|RANGEFINDER).*$"
+            "^\\[PILE\\] INPUT-PORT-(LIGHT_SENSOR_*|TOUCH_SENSOR|RANGEFINDER).*$"
     );
 
     @Test(dataProvider = "ports")
@@ -52,7 +52,7 @@ public class PileInputPortTest {
     public void testGetRaw() throws Exception {
         assertEquals(PileInputPort.RANGEFINDER  .getRaw(), 0);
         assertEquals(PileInputPort.TOUCH_SENSOR .getRaw(), 0);
-        assertEquals(PileInputPort.LINE_SENSOR_L.getRaw(), 0);
-        assertEquals(PileInputPort.LINE_SENSOR_R.getRaw(), 1);
+        assertEquals(PileInputPort.LIGHT_SENSOR_L.getRaw(), 0);
+        assertEquals(PileInputPort.LIGHT_SENSOR_R.getRaw(), 1);
     }
 }


### PR DESCRIPTION
solves #17.

### Overview
This PR modifies the name of `LineSensor` to `LightSensor` because the old name is too specific for the sensor (#17). 

#### NOTE
I briefly checked the careless mistakes of this PR with a command. The result is like this:
```sh
# ag -a line -G '\.java' C
src/main/java/com/pileproject/drivecommand/model/nxt/NxtConstants.java:40:    public static final byte OPEN_WRITE_LINEAR = (byte) 0x89;
src/main/java/com/pileproject/drivecommand/model/nxt/NxtConstants.java:41:    public static final byte OPEN_READ_LINEAR = (byte) 0x8A;
```